### PR TITLE
Add index response and fix sse handler transfer encoding

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>HTML5 Server Side Event Example in Rust</title>
+</head>
+
+<body>
+
+    Hi friend, here are the messages in the "foo" topic:<br>
+
+    <script type="text/javascript">
+        // Create a new HTML5 EventSource
+        var source = new EventSource('/foo');
+
+        // Create a callback for when a new message is received.
+        source.onmessage = function (e) {
+
+            // Append the `data` attribute of the message to the DOM.
+            document.body.innerHTML += e.data + '<br>';
+        };
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
The Identity transfer encoding in needed with Actix (I believe) in order to get the response flushed. Without this encoding, EventSource will not work in a browser but looks fine via curl.

Opening "http://localhost:8080" shows messages as follows:
```
Hi friend, here are the messages in the "foo" topic:
event 4
event 5
event 6
event 7
```

and so on